### PR TITLE
Update badges in README.md

### DIFF
--- a/CONTRIBURING.md
+++ b/CONTRIBURING.md
@@ -1,0 +1,35 @@
+# Contributing to ToPS
+
+### Team members
+
+This project was originally developed as part of the eXtreme Programming course of 2015 at University of São Paulo.
+
+To know the main contributors of this project check [CONTRIBUTORS](https://github.com/acessoajustica/acessoajustica/blob/master/CONTRIBUTORS).
+
+### Adding new features
+
+* Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.
+* Open an [issue](https://github.com/acessoajustica/acessoajustica/issues) with your proposal, to see if somebody else has done it.
+* Check out the [issue tracker](https://github.com/acessoajustica/acessoajustica/issues) to make sure someone already hasn't requested it and/or contributed it.
+* Fork the project.
+* Start a feature/bugfix branch.
+* Commit and push until you are happy with your contribution.
+* Make sure to add tests for the feature/bugfix. This is important so I don't break it in a future version unintentionally.
+* Please try not to mess with the Gemfile, version, or history. If you want to have your own version, or is otherwise necessary, that is fine, but please isolate it to its own commit so I can cherry-pick around it.
+
+### Bug triage
+
+* You can help report bugs by opening an [issue](https://github.com/acessoajustica/acessoajustica/issues) and labeling it as a `bug`.
+* You can look through the existing bugs [here](https://github.com/acessoajustica/acessoajustica/issues?q=is%3Aopen+is%3Aissue+label%3Abug).
+* Look at existing bugs and help us understand:
+  * Is the bug reproducible? 
+  * Is it reproducible in other OS? 
+  * What are the steps to reproduce? 
+
+### Testing
+
+We use [RSpec](http://rspec.info/) for unit/integration tests and [Cucumber](https://cucumber.io/) for acceptance tests. 
+
+In order to run all available tests just type `./script/alfredo test`. Our countinous integration is made with [Travis](https://travis-ci.org/acessoajustica/acessoajustica). 
+
+To see the test coverage, check our page in [Corveralls](https://coveralls.io/r/acessoajustica/acessoajustica).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,29 @@
 LabXP 2015: Acesso à Justiça
 ==============================
 
-[![Code Climate](https://codeclimate.com/github/acessoajustica/acessoajustica/badges/gpa.svg)](https://codeclimate.com/github/acessoajustica/acessoajustica)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/acessoajustica/acessoajustica/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/acessoajustica/acessoajustica/?branch=dev)
-[![Build Status](https://travis-ci.org/acessoajustica/acessoajustica.svg?branch=dev)](https://travis-ci.org/acessoajustica/acessoajustica)
-[![Coverage Status](https://coveralls.io/repos/acessoajustica/acessoajustica/badge.svg?branch=dev)](https://coveralls.io/r/acessoajustica/acessoajustica?branch=dev)
-[![Dependency Status](https://gemnasium.com/acessoajustica/acessoajustica.svg)](https://gemnasium.com/acessoajustica/acessoajustica)
-[![License](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/acessoajustica/acessoajustica/blob/master/LICENSE)
+[![Build Status](https://img.shields.io/travis/acessoajustica/acessoajustica.svg)]
+                (https://travis-ci.org/acessoajustica/acessoajustica)
+[![Coverage Status](https://img.shields.io/coveralls/acessoajustica/acessoajustica.svg)]
+                   (https://coveralls.io/r/acessoajustica/acessoajustica?branch=dev)
+[![Dependency Status](https://img.shields.io/gemnasium/acessoajustica/acessoajustica.svg)]
+                     (https://gemnasium.com/acessoajustica/acessoajustica)
+[![Code Climate](https://img.shields.io/codeclimate/github/acessoajustica/acessoajustica.svg)]
+                (https://codeclimate.com/github/acessoajustica/acessoajustica)
+[![Scrutinizer](https://img.shields.io/scrutinizer/g/acessoajustica/acessoajustica.svg)]
+               (https://scrutinizer-ci.com/g/acessoajustica/acessoajustica)
+[![License](https://img.shields.io/github/license/acessoajustica/acessoajustica.svg)]
+           (https://github.com/acessoajustica/acessoajustica/blob/master/LICENSE)
+
+[![Backlog](https://badge.waffle.io/acessoajustica/acessoajustica.svg?title=Backlog)]
+           (http://waffle.io/acessoajustica/acessoajustica)
+[![Ready](https://badge.waffle.io/acessoajustica/acessoajustica.svg?title=Ready)]
+         (http://waffle.io/acessoajustica/acessoajustica)
+[![In Progress](https://badge.waffle.io/acessoajustica/acessoajustica.svg?title=In Progress)]
+               (http://waffle.io/acessoajustica/acessoajustica)
+[![Testing](https://badge.waffle.io/acessoajustica/acessoajustica.svg?title=Testing)]
+           (http://waffle.io/acessoajustica/acessoajustica)
+[![Done](https://badge.waffle.io/acessoajustica/acessoajustica.svg?title=Done)]
+        (http://waffle.io/acessoajustica/acessoajustica)
 
 This repository contains a ruby on rails project for the
 [Legal Department XI de Agosto](http://djonzedeagosto.org.br/). The project
@@ -85,4 +102,3 @@ The app runs at ```localhost:3000```.
 ## Troubleshooting
 
 Refer to https://docs.docker.com/compose/rails/.
-


### PR DESCRIPTION
Use standardized http://shields.io/ API to get badges. Add https://waffle.io/ badges for issue tracking.
